### PR TITLE
electronのAPIの新しい呼び出し方に追随した

### DIFF
--- a/src/coffee/index.coffee
+++ b/src/coffee/index.coffee
@@ -1,7 +1,8 @@
-app           = require 'app'
-BrowserWindow = require 'browser-window'
+electron      = require 'electron'
+app           = electron.app
+BrowserWindow = electron.BrowserWindow
 PeCaCtrl      = require "./browser/peercast_controller"
-ipc           = require 'ipc'
+ipc           = electron.ipcMain
 
 # PeerCastStaionが起動していることを確認する
 ipc.on 'isAlive', (e, arg) ->
@@ -55,6 +56,6 @@ app.on 'ready', ->
   mainWindow = new BrowserWindow
     "width":  400
     "height": 300
-  mainWindow.loadUrl "file://#{__dirname}/renderer/index.html"
+  mainWindow.loadURL "file://#{__dirname}/renderer/index.html"
   mainWindow.on 'close', ->
     mainWindow = null


### PR DESCRIPTION
electron のAPIが変わって、起動しなくなっていたので(手元の環境で)起動するようにしました。

electron のコンポーネントは、require せずに electron オブジェクトのプロパティとしてアクセスできるようになったようです。
